### PR TITLE
[add] explicit syntax highlighting language override

### DIFF
--- a/app/resources/repositories.coffee
+++ b/app/resources/repositories.coffee
@@ -39,7 +39,10 @@ Marked = (text) ->
       else if token.depth == 3
         token.depth = "#{token.depth} id='#{current_h2}/#{to_param}'"
     else if token.type is "code"
-      token.text = hljs.highlightAuto(token.text).value
+      if token.lang in Object.keys(hljs.LANGUAGES)
+        token.text = hljs.highlight(token.lang, token.text).value
+      else
+        token.text = hljs.highlightAuto(token.text).value
       token.escaped = true;
     i++
   text = marked_.parser(tokens)


### PR DESCRIPTION
Hi Jerome,

I just experienced some issues with `highlight.js`' language auto-detection and decided to use `marked`'s ability to parse

``````
```any-given-language # => is parsed as 'any-given-language' in token.lang 
random:= code;
```
``````

for explicitly highlighting a certain programming language.

This pull request includes a simple guard to only use this feature if `any-given-language` is containd in `highlight.js`' loaded syntaxes (`hljs.LANGUAGES`)
