### PR TITLE
Menus look better if they don't include the bits in brackets most of the time

### DIFF
--- a/app/models/repository.coffee
+++ b/app/models/repository.coffee
@@ -165,7 +165,7 @@ class Repository
     toc = {}
     navigation.forEach (token, i, arr)->
       id =   token.text.parameterize()
-      n  =   token.text
+      n  =   token.text.replace(/\(.*\)/g,"");
       
       if token.depth == 2
         current_section = id


### PR DESCRIPTION
When function names are used as headings they often have fairly long lists of parameters.  These lists are rarely helpful to include in the menu text.  Perhaps this should be an option though.
