### PR TITLE
Top-right image not showing up cont.

### DIFF
--- a/app/views/repositories/show.eco
+++ b/app/views/repositories/show.eco
@@ -49,7 +49,7 @@
   </div>
   <div id="content">
     <% if @name && @config.ribbon: %>
-      <a href="http://github.com/<%= @name %>" id="github-ribbon"><img src="https://a248.e.akamai.net/assets.github.com/img/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
+      <a href="http://github.com/<%= @name %>" id="github-ribbon"><img src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
     <% end %>
     <%- @compiled %>
   </div>


### PR DESCRIPTION
This fixes it, you're using an old URL that doesn't work everywhere anymore cause it isn't on all the CDN servers. It's simply still cached in your area. Using the new one as specified on https://github.com/blog/273-github-ribbons
